### PR TITLE
Silence unused var warning

### DIFF
--- a/acls.c
+++ b/acls.c
@@ -765,6 +765,7 @@ static int recv_rsync_acl(int f, item_list *racl_list, SMB_ACL_TYPE_T type, mode
 	/* If we received a superfluous mask, throw it away. */
 	duo_item->racl.mask_obj = NO_ENTRY;
 	(void)mode;
+	(void)computed_mask_bits;
 #else
 	if (duo_item->racl.names.count && duo_item->racl.mask_obj == NO_ENTRY) {
 		/* Mask must be non-empty with lists. */


### PR DESCRIPTION
recv_ida_entries still needs to be called regardless, so we cannot take that out. Let's just quiet the compiler instead.