### PR TITLE
sanitise results of stat()/lstat() on Solaris

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -357,9 +357,14 @@ int do_mkstemp(char *template, mode_t perms)
 int do_stat(const char *path, STRUCT_STAT *st)
 {
 #ifdef USE_STAT64_FUNCS
-	return stat64(path, st);
+	int r = stat64(path, st);
 #else
-	return stat(path, st);
+	int r = stat(path, st);
+#endif
+#if defined __sun && defined HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
+	return stat_time_normalize(r, st);
+#else
+	return r;
 #endif
 }
 
@@ -367,9 +372,14 @@ int do_lstat(const char *path, STRUCT_STAT *st)
 {
 #ifdef SUPPORT_LINKS
 # ifdef USE_STAT64_FUNCS
-	return lstat64(path, st);
+	int r = lstat64(path, st);
 # else
-	return lstat(path, st);
+	int r = lstat(path, st);
+# endif
+# if defined __sun && defined HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
+	return stat_time_normalize(r, st);
+# else
+	return r;
 # endif
 #else
 	return do_stat(path, st);


### PR DESCRIPTION
Solaris 11 (possibly only 11.4) can return negative values for st_atim.tv_nsec, st_mtim.tv_nsec and st_ctim.tv_nsec.

Gnulib already identifies this as an issue and works around it with stat_time_normalize().  I've adapted that function for this patch, omitting st_ctim (unused by rsync) and using only a very simple test for time_t overflow.

The feature test macros used mean this code path will be used on _all_ Solaris builds, but this shouldn't be an issue; it would probably be safe on anything that provides tv_nsec.