### PR TITLE
Fix misc. warnings found by clang-16

### DIFF
--- a/lib/pool_alloc.c
+++ b/lib/pool_alloc.c
@@ -9,7 +9,7 @@ struct alloc_pool
 	size_t			size;		/* extent size		*/
 	size_t			quantum;	/* allocation quantum	*/
 	struct pool_extent	*extents;	/* top extent is "live" */
-	void			(*bomb)();	/* called if malloc fails */
+	void			(*bomb)(const char*, const char*, int);	/* called if malloc fails */
 	int			flags;
 
 	/* statistical data */

--- a/simd-checksum-x86_64.cpp
+++ b/simd-checksum-x86_64.cpp
@@ -68,8 +68,8 @@
 #endif
 
 // Missing from the headers on gcc 6 and older, clang 8 and older
-typedef long long __m128i_u __attribute__((__vector_size__(16), __may_alias__, __aligned__(1)));
-typedef long long __m256i_u __attribute__((__vector_size__(32), __may_alias__, __aligned__(1)));
+typedef long long __m128i_u __attribute__((__vector_size__(16), __may_alias__, __aligned__(16)));
+typedef long long __m256i_u __attribute__((__vector_size__(32), __may_alias__, __aligned__(16)));
 
 /* Compatibility macros to let our SSSE3 algorithm run with only SSE2.
    These used to be neat individual functions with target attributes switching between SSE2 and SSSE3 implementations

--- a/syscall.c
+++ b/syscall.c
@@ -388,11 +388,6 @@ int do_fstat(int fd, STRUCT_STAT *st)
 OFF_T do_lseek(int fd, OFF_T offset, int whence)
 {
 #ifdef HAVE_LSEEK64
-#if !SIZEOF_OFF64_T
-	OFF_T lseek64();
-#else
-	off64_t lseek64();
-#endif
 	return lseek64(fd, offset, whence);
 #else
 	return lseek(fd, offset, whence);


### PR DESCRIPTION
These warnings may seem benign but will soon turn into compilation errors, starting with clang-17 and gcc-14. I tried hard to find a use for the duplicated (and incorrect) lseek prototypes, but could not find any.
The alignment issue was also flagged by clang. I'm not a SIMD expert but explicit 1-byte aligment for a vector seems wrong.

With these fixes rsync itself is now 100% warning-free :)
