### PR TITLE
rrsync: fix wrong parameter name in manpage SYNOPSIS

### DIFF
--- a/support/rrsync.1.md
+++ b/support/rrsync.1.md
@@ -5,7 +5,7 @@ rrsync - a script to setup restricted rsync users via ssh logins
 ## SYNOPSIS
 
 ```
-rrsync [-ro|-rw] [-munge] [-no-del] [-no-lock] [-no-overwrite]  DIR
+rrsync [-ro|-wo] [-munge] [-no-del] [-no-lock] [-no-overwrite]  DIR
 ```
 
 The single non-option argument specifies the restricted _DIR_ to use. It can be


### PR DESCRIPTION
Replace ¨rw¨ with ¨ro¨.

Reported on Debian by Adriano Rafael Gomes <adrianorg@debian.org>