### PR TITLE
When not using the builtin zlib, link it before linking libcrypto, as libcrypto depends on zlib.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -424,6 +424,26 @@ case $host_os in
 	       * ) AC_MSG_RESULT(no);;
 esac
 
+# We default to using our zlib unless --with-included-zlib=no is given.
+if test x"$with_included_zlib" != x"no"; then
+    with_included_zlib=yes
+elif test x"$ac_cv_header_zlib_h" != x"yes"; then
+    with_included_zlib=yes
+fi
+if test x"$with_included_zlib" != x"yes"; then
+    AC_CHECK_LIB(z, deflateParams, , [with_included_zlib=yes])
+fi
+
+AC_MSG_CHECKING([whether to use included zlib])
+if test x"$with_included_zlib" = x"yes"; then
+    AC_MSG_RESULT($srcdir/zlib)
+    BUILD_ZLIB='$(zlib_OBJS)'
+    CFLAGS="-I$srcdir/zlib $CFLAGS"
+else
+    AC_DEFINE(EXTERNAL_ZLIB, 1, [Define to 1 if using external zlib])
+    AC_MSG_RESULT(no)
+fi
+
 AC_MSG_CHECKING([whether to enable use of openssl crypto library])
 AC_ARG_ENABLE([openssl],
 	AS_HELP_STRING([--disable-openssl],[disable to omit openssl crypto library]))
@@ -1093,26 +1113,6 @@ if test x"$with_included_popt" = x"yes"; then
 	AC_MSG_WARN([included libpopt will use malloc, not alloca (which wastes a small amount of memory)])
     fi
 else
-    AC_MSG_RESULT(no)
-fi
-
-# We default to using our zlib unless --with-included-zlib=no is given.
-if test x"$with_included_zlib" != x"no"; then
-    with_included_zlib=yes
-elif test x"$ac_cv_header_zlib_h" != x"yes"; then
-    with_included_zlib=yes
-fi
-if test x"$with_included_zlib" != x"yes"; then
-    AC_CHECK_LIB(z, deflateParams, , [with_included_zlib=yes])
-fi
-
-AC_MSG_CHECKING([whether to use included zlib])
-if test x"$with_included_zlib" = x"yes"; then
-    AC_MSG_RESULT($srcdir/zlib)
-    BUILD_ZLIB='$(zlib_OBJS)'
-    CFLAGS="-I$srcdir/zlib $CFLAGS"
-else
-    AC_DEFINE(EXTERNAL_ZLIB, 1, [Define to 1 if using external zlib])
     AC_MSG_RESULT(no)
 fi
 


### PR DESCRIPTION
This prevents "undefined symbol" errors which might arise from libcrypto.a if linking openssl statically.

This happens to me as:
 - I build my own zlib, which is a recent one (1.31)
 - build my own OpenSSL against the above zlib
 - everything is link statically
 - I configure rsync with `--with-included-zlib=no`.
 
 With this configuration, rsync fails to link with errors like:
 
```
gcc -std=gnu11 -I/workdir/src/rsync-3.2.7/popt -O2 -mmmx -msse -msse2 -msse3 -I/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/build-pack/2.0.102.0/include -I/workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/include -I/workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/include/ncurses -I/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/build-pack/2.0.102.0/internal-python-only-for-build-pack/include -Wno-error -pthread -DHAVE_CONFIG_H -Wall -W -Wno-unused-parameter -O2 -mmmx -msse -msse2 -msse3 -I/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/build-pack/2.0.102.0/include -I/workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/include -I/workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/include/ncurses -I/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/build-pack/2.0.102.0/internal-python-only-for-build-pack/include -L/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/build-pack/2.0.102.0/lib -L/workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/lib -L/workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/lib64 -L/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/build-pack/2.0.102.0/internal-python-only-for-build-pack/lib -Wno-error -Wl,--dynamic-linker=/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/lib64/ld-linux-x86-64.so.2 -pthread -o rsync flist.o rsync.o generator.o receiver.o cleanup.o sender.o exclude.o util1.o util2.o main.o checksum.o match.o syscall.o log.o backup.o delete.o options.o io.o compat.o hlink.o token.o uidlist.o socket.o hashtable.o usage.o fileio.o batch.o clientname.o chmod.o acls.o xattrs.o progress.o pipe.o  simd-checksum-x86_64.o  params.o loadparm.o clientserver.o access.o connection.o authenticate.o lib/wildmatch.o lib/compat.o lib/snprintf.o lib/mdfour.o lib/md5.o lib/permstring.o lib/pool_alloc.o lib/sysacls.o lib/sysxattrs.o   popt/findme.o  popt/popt.o  popt/poptconfig.o popt/popthelp.o popt/poptparse.o -lz -lzstd -lcrypto 
/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/lib/gcc/x86_64-1a-linux-gnu/4.9.4/../../../../x86_64-1a-linux-gnu/bin/ld: /workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/lib64/libcrypto.a(libcrypto-lib-c_zlib.o): in function `zlib_oneshot_expand_block': 
c_zlib.c:(.text+0xc4b): undefined reference to `uncompress' 
/opt/1A/toolchain/x86_64-2.6.32-v2.0.102/lib/gcc/x86_64-1a-linux-gnu/4.9.4/../../../../x86_64-1a-linux-gnu/bin/ld: /workdir/build/x86_64/build-pack/build-pack-temporary-static-dependencies/install/lib64/libcrypto.a(libcrypto-lib-c_zlib.o): in function `zlib_oneshot_compress_block': 
2 
c_zlib.c:(.text+0xcab): undefined reference to `compress' 
collect2: error: ld returned 1 exit status 
make: *** [Makefile:106: rsync] Error 1
```

To fix fix, make sure we link zlib before we link libcrypto (as zlib may be dependency of libcrypto). This only moves code, without changing anything else.