### PR TITLE
Allow basic connectivity check via rrsync

### DIFF
--- a/support/rrsync
+++ b/support/rrsync
@@ -156,6 +156,10 @@ def main():
     command = os.environ.get('SSH_ORIGINAL_COMMAND', None)
     if not command:
         die("Not invoked via sshd")
+    if command == 'true':
+        # Allow checking connectivity with "ssh <host> true".  (For example,
+        # rsbackup uses this.)
+        sys.exit(0)
     command = command.split(' ', 2)
     if command[0:1] != ['rsync']:
         die("SSH_ORIGINAL_COMMAND does not run rsync")


### PR DESCRIPTION
rsbackup (https://github.com/ewxrjk/rsbackup) uses `ssh <host> true` to check that the host in question is reachable.  I like to configure my backed-up hosts to force the backup system to go via `rrsync`, but I always have to add a local tweak to allow `SSH_ORIGINAL_COMMAND=true` to work.  I think this would be safe enough to include in rrsync.