### PR TITLE
ignore-non-existing-directory: add variant of ignore-non-existing

### DIFF
--- a/options.c
+++ b/options.c
@@ -125,6 +125,7 @@ int fuzzy_basis = 0;
 size_t bwlimit_writemax = 0;
 int ignore_existing = 0;
 int ignore_non_existing = 0;
+int ignore_non_existing_dirs = 0;
 int need_messages_from_generator = 0;
 int max_delete = INT_MIN;
 OFF_T max_size = -1;
@@ -693,6 +694,7 @@ static struct poptOption long_options[] = {
   {"no-one-file-system",0, POPT_ARG_VAL,    &one_file_system, 0, 0, 0 },
   {"no-x",             0,  POPT_ARG_VAL,    &one_file_system, 0, 0, 0 },
   {"update",          'u', POPT_ARG_NONE,   &update_only, 0, 0, 0 },
+  {"ignore-non-existing-directory",0,POPT_ARG_NONE,   &ignore_non_existing_dirs, 0, 0, 0 },
   {"existing",         0,  POPT_ARG_NONE,   &ignore_non_existing, 0, 0, 0 },
   {"ignore-non-existing",0,POPT_ARG_NONE,   &ignore_non_existing, 0, 0, 0 },
   {"ignore-existing",  0,  POPT_ARG_NONE,   &ignore_existing, 0, 0, 0 },
@@ -2903,6 +2905,9 @@ void server_options(char **args, int *argc_p)
 		/* Backward compatibility: send --existing, not --ignore-non-existing. */
 		if (ignore_non_existing)
 			args[ac++] = "--existing";
+
+		if (ignore_non_existing_dirs)
+			args[ac++] = "--ignore-non-existing-directory";
 
 		if (tmpdir) {
 			args[ac++] = "--temp-dir";

--- a/rsync.1.md
+++ b/rsync.1.md
@@ -1844,6 +1844,16 @@ expand it.
     This option is a [TRANSFER RULE](#TRANSFER_RULES), so don't expect any
     exclude side effects.
 
+0.  `--ignore-non-existing-directory`
+
+    This tells rsync to skip creating directories that do not
+    exist yet on the destination.  It is a variation of the
+    [`--ignore-non-existing`](#opt) option that is applied only for
+    directories.
+
+    This option is a [TRANSFER RULE](#TRANSFER_RULES), so don't expect any
+    exclude side effects.
+
 0.  `--ignore-existing`
 
     This tells rsync to skip updating files that already exist on the

--- a/testsuite/ignore-non-existing-directory.test
+++ b/testsuite/ignore-non-existing-directory.test
@@ -1,0 +1,47 @@
+#! /bin/sh
+
+# This program is distributable under the terms of the GNU GPL (see
+# COPYING).
+
+. $suitedir/rsync.fns
+
+makepath "$fromdir/subdir1" "$fromdir/subdir2" "$todir/subdir1"
+echo data >"$fromdir/subdir1/file"
+echo data >"$todir/subdir1/file2"
+echo data >"$fromdir/subdir2/file"
+
+# Test 1: Ensure subdir2 and content under it are not created
+$RSYNC -r --ignore-non-existing-directory -vv "$fromdir/" "$todir/" | tee "$scratchdir/out"
+if [ ! -d "$todir/subdir1" ]; then
+	test_fail 'test 1 failed: subdir1 should have been created'
+fi
+if [ ! -f "$todir/subdir1/file" ]; then
+	test_fail 'test 1 failed: subdir1/file should have been created'
+fi
+if [ ! -f "$todir/subdir1/file2" ]; then
+	test_fail 'test 1 failed: subdir1/file2 should not have been removed'
+fi
+if [ -d "$todir/subdir2" ]; then
+	test_fail 'test 1 failed: subdir2 should not have been created'
+fi
+if [ -f "$todir/subdir2/file" ]; then
+	test_fail 'test 1 failed: subdir2/file should not have been created'
+fi
+
+# Test 2: Also ensure that other delete handling was not impacted
+$RSYNC -r --delete --ignore-non-existing-directory -vv "$fromdir/" "$todir/" | tee "$scratchdir/out"
+if [ ! -d "$todir/subdir1" ]; then
+	test_fail 'test 2 failed: subdir1 should have been created'
+fi
+if [ ! -f "$todir/subdir1/file" ]; then
+	test_fail 'test 2 failed: subdir1/file should have been created'
+fi
+if [ -f "$todir/subdir1/file2" ]; then
+	test_fail 'test 2 failed: subdir1/file2 should have been removed'
+fi
+if [ -d "$todir/subdir2" ]; then
+	test_fail 'test 2 failed: subdir2 should not have been created'
+fi
+if [ -f "$todir/subdir2/file" ]; then
+	test_fail 'test 2 failed: subdir2/file should not have been created'
+fi


### PR DESCRIPTION
Add new option --ignore-non-existing-directory, that is a variant of --ignore-non-existing, but applies ONLY to directories.

This was previously proposed in bug #8366, but I independently had a use case for it in the Gentoo infrastructure.

Reference: https://bugzilla.samba.org/show_bug.cgi?id=8366
Reference: http://superuser.com/questions/316561/rsync-synchronizing-files-only-without-creating-folders-on-destination
Reference: https://github.com/RsyncProject/rsync-patches/issues/8
Reference: https://lists.samba.org/archive/rsync/2015-November/030455.html