### PR TITLE
Apple silicon linker path details

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -232,6 +232,9 @@ not completely implement the "New Sockets" API.
 [This site][5] says that Apple started to support IPv6 in 10.2 (Jaguar).  If
 your build fails, try again after running configure with `--disable-ipv6`.
 
+Apple Silicon macs may install packages in a slightly different location and require flags.
+CFLAGS="-I /opt/homebrew/include" LDFLAGS="-L /opt/homebrew/lib"
+
 [5]: http://www.ipv6.org/impl/mac.html
 
 ## IBM AIX notes


### PR DESCRIPTION
I added some notes for under macos for the install.md to make it a bit more clear how to link libraries for m series macs due to the new non standard install location of homebrew packages.