### PR TITLE
acls: sync type for orig_umask and clear macOS compilation warnings

### DIFF
--- a/acls.c
+++ b/acls.c
@@ -28,7 +28,7 @@ extern int dry_run;
 extern int am_root;
 extern int read_only;
 extern int list_only;
-extern int orig_umask;
+extern mode_t orig_umask;
 extern int numeric_ids;
 extern int inc_recurse;
 extern int preserve_devices;
@@ -982,7 +982,7 @@ static int set_rsync_acl(const char *fname, acl_duo *duo_item,
 		 && !pack_smb_acl(&duo_item->sacl, &duo_item->racl))
 			return -1;
 #ifdef HAVE_OSX_ACLS
-		mode = 0; /* eliminate compiler warning */
+		(void)mode; /* eliminate compiler warning */
 #else
 		if (type == SMB_ACL_TYPE_ACCESS) {
 			cur_mode = change_sacl_perms(duo_item->sacl, &duo_item->racl, cur_mode, mode);


### PR DESCRIPTION
When sizeof(mode_t) != sizeof(int) it will result in unintentional reads of global memory as shown when running the tests with sanitizers:

```
==31861==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00010b7e3240 at pc 0x00010b5f192f bp 0x7ff7b4a3d6b0 sp 0x7ff7b4a3d6a8
READ of size 4 at 0x00010b7e3240 thread T0
    #0 0x10b5f192e in default_perms_for_dir acls.c:1093
    #1 0x10b503332 in recv_generator generator.c:1339
    #2 0x10b50d8a9 in generate_files generator.c:2293
    #3 0x10b554ecb in do_recv main.c:1114
    #4 0x10b54ee66 in start_server main.c:1261
    #5 0x10b54e2f3 in child_main main.c:1234
    #6 0x10b605877 in local_child pipe.c:166
    #7 0x10b558a26 in start_client main.c:1577
    #8 0x10b556cce in main main.c:1848
    #9 0x7ff816f15365 in start+0x795 (dyld:x86_64+0xfffffffffff5c365)

0x00010b7e3240 is located 32 bytes before global variable 'sender_keeps_checksum' defined in 'main.c' (0x10b7e3260) of size 4
0x00010b7e3242 is located 0 bytes after global variable 'orig_umask' defined in 'main.c' (0x10b7e3240) of size 2
  'orig_umask' is ascii string ''
```

While at it, silence again a warning that is being triggered by Apple's Clang 15.