### PR TITLE
Return from #list command with 0

### DIFF
--- a/clientserver.c
+++ b/clientserver.c
@@ -1371,7 +1371,7 @@ int start_daemon(int f_in, int f_out)
 		rprintf(FLOG, "module-list request from %s (%s)\n",
 			host, addr);
 		send_listing(f_out);
-		return -1;
+		return 0;
 	}
 
 	if (*line == '#') {


### PR DESCRIPTION
The "#list" command should not be treated as a failure when it is both a legitimate request by the client, and correctly answered by the server. It is commonly used for assessing whether a rsync endpoint is healthy, having it return with a non-zero exit code causes misleading error reports, and, in case of socket activation, failed service instances on the server.