### PR TITLE
feat: insert `--` between RSH and rsync commands

### DIFF
--- a/main.c
+++ b/main.c
@@ -586,6 +586,10 @@ static pid_t do_cmd(char *cmd, char *machine, char *user, char **remote_argv, in
 		args[argc++] = machine;
 #endif
 
+		// include a `--` before any rsync commands to indicate that
+		// all following arguments are intended as positional
+		// and should not be parsed by the shell
+		args[argc++] = "--";
 		args[argc++] = rsync_path;
 
 		if (blocking_io < 0 && (strcmp(t, "rsh") == 0 || strcmp(t, "remsh") == 0))


### PR DESCRIPTION
Hi there!

I ran into some minor issue whilst tinkering with rsync and a new remote shell program. I noticed that rsync does not add the now common `--` indicating the end of parsable arguments to the program between the RSH flags and rsync command.

Effectively, this changes the passed command from

```sh
ssh [opts] <destination> rsync [opts] src dst
```
to
```sh
ssh [opts] <destination> -- rsync [opts] src dst
```

To the best of my knowledge, this practice is an untold (?) “standard”, in use by virtually all applications in my daily use.

I have tested this change with the test scripts (2 tests skipped: *crtimes* and *protected-regular*) and with the current SSH implementation (OpenSSH_9.9p1, OpenSSL 3.3.2 3 Sep 2024; I can assert, however, that I have used this practice for 3+ years with OpenSSH). As such, I do not believe there to be any significant impact; nevertheless, I would be very appreciative of input about situations I did not think about. Do you know any other commonly used remote shells I should test?

Furthermore, I was unable to find contributing guidance, so please do not hesitate to indicate code formatting, commenting or other requirements I did not follow.

Cheers and many thanks for a utility I have had the pleasure of using for years (and will continue to)!