### PR TITLE
GCC15(-std=gnu23) adjustment: Fix function pointer cast in qsort()

### DIFF
--- a/hlink.c
+++ b/hlink.c
@@ -117,7 +117,7 @@ static void match_gnums(int32 *ndx_list, int ndx_count)
 	struct ht_int32_node *node = NULL;
 	int32 gnum, gnum_next;
 
-	qsort(ndx_list, ndx_count, sizeof ndx_list[0], (int (*)()) hlink_compare_gnum);
+	qsort(ndx_list, ndx_count, sizeof ndx_list[0], (int (*)(const void*, const void*))hlink_compare_gnum);
 
 	for (from = 0; from < ndx_count; from++) {
 		file = hlink_flist->sorted[ndx_list[from]];


### PR DESCRIPTION
~1. Suppress -Wold-style-definition warnings globally since we prefer old-style definitions.~
2. Fix hlink.c's cast in qsort() call to properly declare type.
~3. Fix pool_alloc.c's function pointer type to match its usage.~
~4. Fix syscall.c's lseek64 forward declarations.~
~5. Fix bool typedef conflict in wildtest.c by renaming to rsync_bool.~

This cleans up the build with modern compilers (GCC15) while maintaining compatibility with older versions. The qsort comparison function cast in particular is now more type-safe.

Closes #664 