### PR TITLE
un-initialization of a static char * (fix of issue #637)

### DIFF
--- a/checksum.c
+++ b/checksum.c
@@ -361,7 +361,7 @@ void get_checksum2(char *buf, int32 len, char *sum)
 	  case CSUM_MD4_ARCHAIC: {
 		md_context m;
 		int32 i;
-		static char *buf1;
+		static char *buf1 = NULL;
 		static int32 len1;
 
 		mdfour_begin(&m);


### PR DESCRIPTION
to ininitialize buf1 in case it is not initiliazed 