### PR TITLE
syscall: fix a Y2038 bug by replacing `Int32x32To64` with multiplication

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -476,7 +476,7 @@ int do_SetFileTime(const char *path, time_t crtime)
 	free(pathw);
 	if (handle == INVALID_HANDLE_VALUE)
 	    return -1;
-	int64 temp_time = Int32x32To64(crtime, 10000000) + 116444736000000000LL;
+	int64 temp_time = (crtime * 10000000LL) + 116444736000000000LL;
 	FILETIME birth_time;
 	birth_time.dwLowDateTime = (DWORD)temp_time;
 	birth_time.dwHighDateTime = (DWORD)(temp_time >> 32);


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>