### PR TITLE
Fix memory leak in popt_unalias()

### DIFF
--- a/options.c
+++ b/options.c
@@ -1319,6 +1319,9 @@ static void popt_unalias(poptContext con, const char *opt)
 	unalias.argv[0] = strdup(opt);
 
 	poptAddAlias(con, unalias, 0);
+
+	free((void*)unalias.argv[0]);
+	free((void*)unalias.argv);
 }
 
 char *alt_dest_opt(int type)


### PR DESCRIPTION
Free memory allocated by strdup() and new_array0() for the poptAlias structure after adding the alias. This prevents memory leaks when parsing daemon and server command-line options.

Observed by valgrind as,
   9 bytes in 1 blocks are definitely lost in loss record 4 of 26
      at 0x48407B4: malloc (vg_replace_malloc.c:381)
      by 0x1307B0: my_alloc (util2.c:83)
      by 0x13AA7D: my_strdup (ifuncs.h:109)
      by 0x13AA7D: popt_unalias (options.c:1319)
      by 0x13D528: parse_arguments (options.c:1374)
      by 0x111FEA: main (main.c:1780)

   9 bytes in 1 blocks are definitely lost in loss record 5 of 26
      at 0x48407B4: malloc (vg_replace_malloc.c:381)
      by 0x1307B0: my_alloc (util2.c:83)
      by 0x13AA7D: my_strdup (ifuncs.h:109)
      by 0x13AA7D: popt_unalias (options.c:1319)
      by 0x13D537: parse_arguments (options.c:1375)
      by 0x111FEA: main (main.c:1780)