### PR TITLE
Fix use-after-free in generator

### DIFF
--- a/generator.c
+++ b/generator.c
@@ -2041,8 +2041,12 @@ int atomic_create(struct file_struct *file, char *fname, const char *slnk, const
 
 	if (!skip_atomic) {
 		if (do_rename(tmpname, fname) < 0) {
+			char *full_tmpname = strdup(full_fname(tmpname));
+			if (full_tmpname == NULL)
+				out_of_memory("atomic_create");
 			rsyserr(FERROR_XFER, errno, "rename %s -> \"%s\" failed",
-				full_fname(tmpname), full_fname(fname));
+				full_tmpname, full_fname(fname));
+			free(full_tmpname);
 			do_unlink(tmpname);
 			return 0;
 		}


### PR DESCRIPTION
full_fname() will free the return value in the next call so we need to duplicate it before passing it to rsyserr.

Fixes: https://github.com/RsyncProject/rsync/issues/704