### PR TITLE
popt: remove dependency on alloca

### DIFF
--- a/popt/findme.c
+++ b/popt/findme.c
@@ -25,12 +25,15 @@ const char * findProgramPath(const char * argv0)
     if (path == NULL) return NULL;
 
     bufsize = strlen(path) + 1;
-    start = pathbuf = alloca(bufsize);
+    start = pathbuf = malloc(bufsize);
     if (pathbuf == NULL) return NULL;	/* XXX can't happen */
     strlcpy(pathbuf, path, bufsize);
     bufsize += sizeof "/" - 1 + strlen(argv0);
     buf = malloc(bufsize);
-    if (buf == NULL) return NULL;	/* XXX can't happen */
+    if (buf == NULL) {
+	    free(pathbuf);
+	    return NULL;	/* XXX can't happen */
+    }
 
     chptr = NULL;
     /*@-branchstate@*/
@@ -39,8 +42,10 @@ const char * findProgramPath(const char * argv0)
 	    *chptr = '\0';
 	snprintf(buf, bufsize, "%s/%s", start, argv0);
 
-	if (!access(buf, X_OK))
+	if (!access(buf, X_OK)) {
+	    free(pathbuf);
 	    return buf;
+	}
 
 	if (chptr) 
 	    start = chptr + 1;
@@ -49,6 +54,7 @@ const char * findProgramPath(const char * argv0)
     } while (start && *start);
     /*@=branchstate@*/
 
+    free(pathbuf);
     free(buf);
 
     return NULL;


### PR DESCRIPTION
fixes build on systems without alloca, such as NonStop ia64
