### PR TITLE
fixed build error on ia64 NonStop

### DIFF
--- a/popt/findme.c
+++ b/popt/findme.c
@@ -9,6 +9,10 @@
 #include "system.h"
 #include "findme.h"
 
+#ifndef HAVE_STRLCPY
+size_t strlcpy(char *d, const char *s, size_t bufsize);
+#endif
+
 const char * findProgramPath(const char * argv0)
 {
     char * path = getenv("PATH");


### PR DESCRIPTION
it treats missing prototype as an error, not warning