### PR TITLE
bool is a keyword in C23

### DIFF
--- a/wildtest.c
+++ b/wildtest.c
@@ -32,7 +32,9 @@ int fnmatch_errors = 0;
 
 int wildmatch_errors = 0;
 
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
 typedef char bool;
+#endif
 
 int output_iterations = 0;
 int explode_mod = 0;


### PR DESCRIPTION
GCC15 has landed in Fedora Rawhide and 'bool' is a new keyword in C23 standard. I have added a condition around the typedef for bool so that with newer GCC, the build won't fail with following error:
```
wildtest.c:35:14: error: ‘bool’ cannot be defined via ‘typedef’
   35 | typedef char bool;
      |              ^~~~
wildtest.c:35:14: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
wildtest.c:35:1: warning: useless type name in empty declaration
   35 | typedef char bool;
      | ^~~~~~~
```