### PR TITLE
Fix flaky hardlinks test

### DIFF
--- a/testsuite/hardlinks.test
+++ b/testsuite/hardlinks.test
@@ -81,7 +81,7 @@ diff $diffopt "$name1" "$todir" || test_fail "solo copy of name1 failed"
 # enabled (this has broken in 3.4.0 so far, so we need this test).
 rm -rf "$fromdir" "$todir"
 makepath "$fromdir/sym" "$todir"
-checkit "$RSYNC -aH '$fromdir/sym' '$todir'" "$fromdir" "$todir"
+checkit "$RSYNC -aH '$fromdir/' '$todir/'" "$fromdir" "$todir"
 
 # The script would have aborted on error, so getting here means we've won.
 exit 0


### PR DESCRIPTION
The test was added in dc34990, it turns out that it's flaky. It failed once on the Debian build infra, cf. [1].

The problem is that the command `rsync -aH '$fromdir/sym' '$todir'` updates the mod time of `$todir`, so there might be a diff between the output of `rsync_ls_lR $fromdir` and `rsync_ls_lR $todir`, if ever rsync runs 1 second (or more) after the directories were created.

To clarify: it's easy to make the test fails 100% of the times with this change:

```
 makepath "$fromdir/sym" "$todir"
+sleep 5
 checkit "$RSYNC -aH '$fromdir/sym' '$todir'" "$fromdir" "$todir"
```

The fix proposed here is in line with other tests in hardlinks.test, as far as I can see all the tests use a trailing slash for the `$fromdir` and `$todir` arguments.

I tested that, after this commit, the test still catches the regression in rsync 3.4.0.

Fixes: https://github.com/RsyncProject/rsync/issues/735

[1]: https://buildd.debian.org/status/fetch.php?pkg=rsync&arch=ppc64el&ver=3.4.1%2Bds1-1&stamp=1741147156&raw=0