### PR TITLE
Add negation to merge files, adds `CACHEDIR.TAG` support

### DIFF
--- a/rsync.h
+++ b/rsync.h
@@ -1010,6 +1010,7 @@ struct map_struct {
 #define FILTRULE_CLEAR_LIST	(1<<18)/* this item is the "!" token */
 #define FILTRULE_PERISHABLE	(1<<19)/* perishable if parent dir goes away */
 #define FILTRULE_XATTR		(1<<20)/* rule only applies to xattr names */
+#define FILTRULE_DEFAULT_NONE	(1<<21)/* for dir-merge, default do - ** */
 
 #define FILTRULES_SIDES (FILTRULE_SENDER_SIDE | FILTRULE_RECEIVER_SIDE)
 


### PR DESCRIPTION
This PR makes the previously forbidden `!` modifier available to `merge` and `dir-merge` filters.
It's effect is that it turns the default for that filter file to `- /**` (which is added *after* the merge file rules.

Additionally, unless the `e` modifier is also set, another rule for including the rules file is added.

This by itself makes it possible to support `CACHEDIR.TAG` files by specifying `--filter='dir-merge,+! CACHEDIR.TAG'`. The `CACHEDIR.TAG` is still parsed. The first line is usually `Signature: 8a477f597d28d172789f06886806bc55`, so currently a rule for that is added, but it would in practice never(tm) match.

I could imagine adding another modifier specifying a merge file is just a tag, meaning it is not parsed at all. Maybe `t`. Or, special-case the `CACHEDIR.TAG` filename. Or, ignore all rules with the exact content `Signature: 8a477f597d28d172789f06886806bc55`. But also this is already very usable as is, and IMO a pretty small change.

Additionally it would be easy to add aliases like `tar` and others have them:

```
       --exclude-caches
              Exclude contents of directories containing file CACHEDIR.TAG,
              except for the tag file itself. -> --filter='dir-merge,+! CACHEDIR.TAG'

       --exclude-caches-all
              Exclude directories containing file CACHEDIR.TAG and the file
              itself. -> --filter='dir-merge,+e! CACHEDIR.TAG'

       --exclude-caches-under
              Exclude everything under directories containing CACHEDIR.TAG
```

Let me know what you think!

Implements #499.