### PR TITLE
Add detailed error information for filtered_fwrite failures

### DIFF
--- a/log.c
+++ b/log.c
@@ -229,7 +229,12 @@ static void filtered_fwrite(FILE *f, const char *in_buf, int in_len, int use_isp
 	while (in_buf < end) {
 		if (ob - outbuf >= (int)sizeof outbuf - 10) {
 			if (fwrite(outbuf, ob - outbuf, 1, f) != 1)
+			{
+				int fwrite_errno = errno;
+				FILE *fp = (f == stderr) ? stdout : stderr;
+				fprintf(fp, "filtered_fwrite(): fwrite() error: %s [%s]\n", strerror(fwrite_errno), who_am_i());
 				exit_cleanup(RERR_MESSAGEIO);
+			}
 			ob = outbuf;
 		}
 		if ((in_buf < end - 4 && *in_buf == '\\' && in_buf[1] == '#'
@@ -242,7 +247,12 @@ static void filtered_fwrite(FILE *f, const char *in_buf, int in_len, int use_isp
 	if (end_char) /* The "- 10" above means that there is always room for one more char here. */
 		*ob++ = end_char;
 	if (ob != outbuf && fwrite(outbuf, ob - outbuf, 1, f) != 1)
+	{
+		int fwrite_errno = errno;
+		FILE *fp = (f == stderr) ? stdout : stderr;
+		fprintf(fp, "filtered_fwrite(): fwrite() error: %s [%s]\n", strerror(fwrite_errno), who_am_i());
 		exit_cleanup(RERR_MESSAGEIO);
+	}
 }
 
 /* this is the underlying (unformatted) rsync debugging function. Call


### PR DESCRIPTION
I frequently see the following error in our local 
```
2025/04/24 01:13:29 [905477] send_files(632399, /var/ms/01/002/002/tbms1s_613F1EA121BB53)
2025/04/24 01:13:29 [905477] file has vanished: "/var/ms/01/002/002/tbms1s_613F1EA121BB53"
2025/04/24 01:13:29 [905477] rsync error: errors with program diagnostics (code 13) at log.c(245) [receiver=3.1.3]
2025/04/24 01:13:29 [905477] [receiver] _exit_cleanup(code=13, file=log.c, line=245): about to call exit(13)
```
line 244 and 245 in log.c is:
```
if (ob != outbuf && fwrite(outbuf, ob - outbuf, 1, f) != 1)
	exit_cleanup(RERR_MESSAGEIO);
```
It invokes logging message, but not detailed enough to diagnose how fwrite() fails. This patch should output the errno to stderr or stdout(avoid the 'f' in the previous line) to see what fwrite() happens.

