### PR TITLE
syscall: explain untrusted symlink refusal

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -429,6 +429,10 @@ static int ona_open(const char *path, int flags, mode_t mode, char *out_abs, siz
 				&& ((strcmp(abspath, "/proc") == 0 && strcmp(comp, "self") == 0)
 				 || (strcmp(abspath, "/dev") == 0 && strcmp(comp, "fd") == 0));
 			if (!namespace_pin && lst.st_uid != 0 && lst.st_uid != trusted_uid) {
+				rprintf(FERROR,
+					"refusing to follow a symlink owned by an untrusted user; "
+					"use --insecure-links locally or \"insecure links = yes\" in a "
+					"daemon module only if every path component is trusted\n");
 				saved_errno = ELOOP;
 				goto out;
 			}

--- a/syscall.c
+++ b/syscall.c
@@ -432,7 +432,7 @@ static int ona_open(const char *path, int flags, mode_t mode, char *out_abs, siz
 				rprintf(FERROR,
 					"refusing to follow a symlink owned by an untrusted user; "
 					"use --insecure-links locally or \"insecure links = yes\" in a "
-					"daemon module only if every path component is trusted\n");
+					"daemon module ONLY if every path component is trusted\n");
 				saved_errno = ELOOP;
 				goto out;
 			}

--- a/testsuite/symlink-race-dest_test.py
+++ b/testsuite/symlink-race-dest_test.py
@@ -50,8 +50,20 @@ dest.mkdir(parents=True)
 os.symlink(outside, dest / 'sub')               # attacker-owned dest component
 os.lchown(dest / 'sub', ATT_UID, ATT_UID)
 
-subprocess.run(rsync_argv('-a', f'{src}/sub/', f'{dest}/sub/'),
-               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+proc = subprocess.run(
+    rsync_argv('-a', f'{src}/sub/', f'{dest}/sub/'),
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+
+if proc.returncode == 0:
+    test_fail("attacker-owned destination symlink was not rejected")
+if "refusing to follow a symlink owned by an untrusted user" not in proc.stderr:
+    test_fail(
+        "untrusted destination symlink failure omitted the actionable "
+        f"diagnostic: {proc.stderr!r}"
+    )
 
 escaped = sorted(p.name for p in outside.iterdir())
 if escaped:


### PR DESCRIPTION
Closes #1067

## Summary

Explain when rsync rejects an operator path because a symlink component is owned by an untrusted user.

The existing `ELOOP` result and security policy remain unchanged. The additional diagnostic identifies the ownership rule and points operators to the local and daemon-specific compatibility controls while warning that every path component must be trusted.

The existing cross-UID destination regression now asserts the non-zero exit and actionable diagnostic as well as proving that no files are written through the attacker-owned symlink.